### PR TITLE
Added NSMicrophoneUsageDescription for iOS 10

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -110,6 +110,11 @@ version="2.0.22">
          </config-file>
          <header-file src="src/ios/CDVSound.h" />
          <source-file src="src/ios/CDVSound.m" />
+	     
+     	 <preference name="MICROPHONE_USAGE_DESCRIPTION" default=" " />
+         <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+             <string>$MICROPHONE_USAGE_DESCRIPTION</string>
+         </config-file>
      </platform>
 
     <!-- blackberry10 -->


### PR DESCRIPTION
As required by iOS 10 I added the NSMicrophoneUsageDescription. Without that, the app will instantly crash when you're trying to use the mic.
