### PR TITLE
Fix: Changed logic to always create temp files in the local app storage for Android

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 # Release Notes
 
+### 2.2.2 (Nov 30, 2021)
+* Changed logic to always create temp files in the local app storage rather than trying to use external storage to avoid new android 11 file system restriction issue.
+
 ### 0.2.1 (Sept 5, 2013)
 * CB-4432 copyright notice change
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-media-with-compression",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Cordova Media Plugin with MPEG 4 audio compression for iOS and Android",
   "cordova": {
     "id": "cordova-media-with-compression",

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
 id="cordova-media-with-compression"
-version="2.2.1">
+version="2.2.2">
 
     <name>Media With Compression: Alpha Software Edition</name>
     <description>Cordova Media Plugin with MPEG 4 audio compression for iOS and Android</description>

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -92,6 +92,10 @@ public class AudioHandler extends CordovaPlugin {
 
     }
 
+    public Context getApplicationContext() {
+        return this.cordova.getActivity().getApplicationContext();
+    }
+
     protected void getWritePermission(int requestCode)
     {
         PermissionHelper.requestPermission(this, requestCode, permissions[WRITE_EXTERNAL_STORAGE]);

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-media-tests"
-    version="1.0.1-dev">
+    version="2.2.2">
     <name>Cordova Media Plugin Tests</name>
     <license>Apache 2.0</license>
     <js-module src="tests.js" name="tests">


### PR DESCRIPTION
Changed logic to always create temp files in the local app storage rather than trying to use external storage to avoid the new android 11 file system restriction issue.

based on the PR on the main cordova-plugin-media

https://github.com/j5int/cordova-plugin-media/commit/62edb7f9cb8f7fd9fc0384a46a87f6c1373867b5

The change is tested on Android 9, 10, 11 & 12.